### PR TITLE
Alter example to be compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ This is an example of a pact file:
                         },
                         "$.data.array1": {
                             "matchers": [
-                              { "min": 0, "match": "type" }
+                              { "min": 1, "match": "type" }
                             ]
                         },
                         "$.data.array2": {


### PR DESCRIPTION
The min value must be greater than 0, per https://docs.pact.io/faq#why-is-there-no-support-for-specifying-optional-attributes